### PR TITLE
feat: add type inference with algorithm W

### DIFF
--- a/compiler/algw.ts
+++ b/compiler/algw.ts
@@ -1,0 +1,174 @@
+import { Expr } from "./ast";
+import { Ty, Scheme, tInt, tBool, tUnit, tFun } from "./types";
+import { TyEnv, envEmpty, envExtend, generalize, instantiate } from "./tyenv";
+import {
+  Subst,
+  emptySubst,
+  compose,
+  applyTy,
+  applyScheme,
+  ftvTy,
+  freshTVar,
+} from "./subst";
+
+export type InferResult = { subst: Subst; ty: Ty };
+
+function applyEnv(s: Subst, env: TyEnv): TyEnv {
+  const newEnv = new Map<string, Scheme>();
+  for (const [k, sc] of env.entries()) {
+    newEnv.set(k, applyScheme(s, sc));
+  }
+  return newEnv;
+}
+
+function showTy(t: Ty): string {
+  switch (t.tag) {
+    case "TInt":
+      return "int";
+    case "TBool":
+      return "bool";
+    case "TUnit":
+      return "unit";
+    case "TFun":
+      return `(${showTy(t.from)}->${showTy(t.to)})`;
+    case "TTuple":
+      return `(${t.elts.map(showTy).join(",")})`;
+    case "TVar":
+      return `'${t.id}`;
+  }
+}
+
+function bind(id: number, ty: Ty): Subst {
+  if (ty.tag === "TVar" && ty.id === id) return emptySubst();
+  if (ftvTy(ty).has(id)) {
+    throw new Error(`OccursCheck(tvar=${id}, in=${showTy(ty)})`);
+  }
+  const s: Subst = new Map();
+  s.set(id, ty);
+  return s;
+}
+
+function unify(t1: Ty, t2: Ty): Subst {
+  if (t1.tag === "TFun" && t2.tag === "TFun") {
+    const s1 = unify(t1.from, t2.from);
+    const s2 = unify(applyTy(s1, t1.to), applyTy(s1, t2.to));
+    return compose(s2, s1);
+  }
+  if (t1.tag === "TTuple" && t2.tag === "TTuple") {
+    if (t1.elts.length !== t2.elts.length) {
+      throw new Error(`Mismatch(expected=${showTy(t1)}, actual=${showTy(t2)})`);
+    }
+    let s = emptySubst();
+    for (let i = 0; i < t1.elts.length; i++) {
+      const s1 = unify(applyTy(s, t1.elts[i]), applyTy(s, t2.elts[i]));
+      s = compose(s1, s);
+    }
+    return s;
+  }
+  if (t1.tag === "TVar") return bind(t1.id, t2);
+  if (t2.tag === "TVar") return bind(t2.id, t1);
+  if (t1.tag === t2.tag) return emptySubst();
+  throw new Error(`Mismatch(expected=${showTy(t1)}, actual=${showTy(t2)})`);
+}
+
+export function infer(env: TyEnv, e: Expr): InferResult {
+  switch (e.tag) {
+    case "Int":
+      return { subst: emptySubst(), ty: tInt() };
+    case "Bool":
+      return { subst: emptySubst(), ty: tBool() };
+    case "Unit":
+      return { subst: emptySubst(), ty: tUnit() };
+    case "Var": {
+      const sc = env.get(e.name);
+      if (!sc) throw new Error(`UnboundVariable(name=${e.name})`);
+      return { subst: emptySubst(), ty: instantiate(sc) };
+    }
+    case "Prim": {
+      const r1 = infer(env, e.left);
+      const env1 = applyEnv(r1.subst, env);
+      const r2 = infer(env1, e.right);
+      const s3 = unify(applyTy(r2.subst, r1.ty), tInt());
+      const s4 = unify(applyTy(s3, r2.ty), tInt());
+      const subst = compose(s4, compose(s3, compose(r2.subst, r1.subst)));
+      const resultTy = e.op === "+" || e.op === "-" || e.op === "*" ? tInt() : tBool();
+      return { subst, ty: applyTy(subst, resultTy) };
+    }
+    case "If": {
+      const rc = infer(env, e.cond);
+      const sBool = unify(rc.ty, tBool());
+      const env1 = applyEnv(compose(sBool, rc.subst), env);
+      const rt = infer(env1, e.then_);
+      const env2 = applyEnv(rt.subst, env1);
+      const re = infer(env2, e.else_);
+      const s3 = unify(applyTy(re.subst, rt.ty), re.ty);
+      const subst = compose(s3, compose(re.subst, compose(rt.subst, compose(sBool, rc.subst))));
+      return { subst, ty: applyTy(subst, rt.ty) };
+    }
+    case "Fun": {
+      const a = freshTVar();
+      const env1 = envExtend(env, e.param, { forAll: [], ty: a });
+      const r = infer(env1, e.body);
+      return { subst: r.subst, ty: tFun(applyTy(r.subst, a), r.ty) };
+    }
+    case "App": {
+      const r1 = infer(env, e.callee);
+      const env1 = applyEnv(r1.subst, env);
+      const r2 = infer(env1, e.arg);
+      const b = freshTVar();
+      const s3 = unify(applyTy(r2.subst, r1.ty), tFun(r2.ty, b));
+      const subst = compose(s3, compose(r2.subst, r1.subst));
+      return { subst, ty: applyTy(subst, b) };
+    }
+    case "Let": {
+      const r1 = infer(env, e.value);
+      const env1 = applyEnv(r1.subst, env);
+      const sc = generalize(env1, r1.ty);
+      const env2 = envExtend(env1, e.name, sc);
+      const r2 = infer(env2, e.body);
+      const subst = compose(r2.subst, r1.subst);
+      return { subst, ty: applyTy(r1.subst, r2.ty) };
+    }
+    case "LetRec": {
+      const a = freshTVar();
+      const b = freshTVar();
+      const env1 = envExtend(env, e.name, { forAll: [], ty: tFun(a, b) });
+      const env2 = envExtend(env1, e.param, { forAll: [], ty: a });
+      const r1 = infer(env2, e.body);
+      const s2 = unify(r1.ty, b);
+      const s1 = compose(s2, r1.subst);
+      const env3 = applyEnv(s1, env);
+      const scf = generalize(env3, applyTy(s1, tFun(a, b)));
+      const env4 = envExtend(env3, e.name, scf);
+      const r2 = infer(env4, e.inExpr);
+      const subst = compose(r2.subst, s1);
+      return { subst, ty: applyTy(subst, r2.ty) };
+    }
+    case "Tuple": {
+      let subst = emptySubst();
+      let env1 = env;
+      const tysRaw: Ty[] = [];
+      for (const elt of e.elts) {
+        const r = infer(env1, elt);
+        subst = compose(r.subst, subst);
+        env1 = applyEnv(r.subst, env1);
+        tysRaw.push(r.ty);
+      }
+      return { subst, ty: { tag: "TTuple", elts: tysRaw.map(t => applyTy(subst, t)) } };
+    }
+  }
+}
+
+function initialEnv(): TyEnv {
+  let env = envEmpty();
+  env = envExtend(env, "print_int", { forAll: [], ty: tFun(tInt(), tUnit()) });
+  env = envExtend(env, "print_bool", { forAll: [], ty: tFun(tBool(), tUnit()) });
+  env = envExtend(env, "print_unit", { forAll: [], ty: tFun(tUnit(), tUnit()) });
+  env = envExtend(env, "now_ms", { forAll: [], ty: tFun(tUnit(), tInt()) });
+  return env;
+}
+
+export function typeOf(e: Expr): Ty {
+  const { ty } = infer(initialEnv(), e);
+  return ty;
+}

--- a/compiler/subst.ts
+++ b/compiler/subst.ts
@@ -1,0 +1,83 @@
+import { Ty, TVarId, Scheme, tVar } from "./types";
+import type { TyEnv } from "./tyenv";
+
+export type Subst = Map<TVarId, Ty>;
+
+export function emptySubst(): Subst {
+  return new Map();
+}
+
+export function applyTy(s: Subst, t: Ty): Ty {
+  switch (t.tag) {
+    case "TVar": {
+      const ty = s.get(t.id);
+      return ty ? applyTy(s, ty) : t;
+    }
+    case "TFun":
+      return { tag: "TFun", from: applyTy(s, t.from), to: applyTy(s, t.to) };
+    case "TTuple":
+      return { tag: "TTuple", elts: t.elts.map((el) => applyTy(s, el)) };
+    default:
+      return t;
+  }
+}
+
+export function applyScheme(s: Subst, sc: Scheme): Scheme {
+  const filtered = new Map(s);
+  for (const id of sc.forAll) {
+    filtered.delete(id);
+  }
+  return { forAll: sc.forAll, ty: applyTy(filtered, sc.ty) };
+}
+
+export function compose(s2: Subst, s1: Subst): Subst {
+  const result: Subst = new Map();
+  for (const [v, ty] of s1.entries()) {
+    result.set(v, applyTy(s2, ty));
+  }
+  for (const [v, ty] of s2.entries()) {
+    result.set(v, ty);
+  }
+  return result;
+}
+
+export function ftvTy(t: Ty): Set<TVarId> {
+  switch (t.tag) {
+    case "TInt":
+    case "TBool":
+    case "TUnit":
+      return new Set();
+    case "TVar":
+      return new Set([t.id]);
+    case "TFun": {
+      const s = ftvTy(t.from);
+      for (const v of ftvTy(t.to)) s.add(v);
+      return s;
+    }
+    case "TTuple": {
+      const s = new Set<TVarId>();
+      for (const el of t.elts) {
+        for (const v of ftvTy(el)) s.add(v);
+      }
+      return s;
+    }
+  }
+}
+
+export function ftvScheme(sc: Scheme): Set<TVarId> {
+  const vars = ftvTy(sc.ty);
+  for (const id of sc.forAll) vars.delete(id);
+  return vars;
+}
+
+export function ftvEnv(env: TyEnv): Set<TVarId> {
+  const s = new Set<TVarId>();
+  for (const [, sc] of env.entries()) {
+    for (const v of ftvScheme(sc)) s.add(v);
+  }
+  return s;
+}
+
+export function freshTVar(): Ty {
+  return tVar();
+}

--- a/compiler/tests/types.spec.ts
+++ b/compiler/tests/types.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "../parser";
+import { typeOf } from "../algw";
+import { tInt, tBool } from "../types";
+
+describe("types", () => {
+  it("simple", () => {
+    expect(typeOf(parse("1 + 2"))).toEqual(tInt());
+    expect(typeOf(parse("if true then 1 else 2"))).toEqual(tInt());
+  });
+
+  it("higher-order", () => {
+    expect(typeOf(parse("let id = fun x -> x in id 3"))).toEqual(tInt());
+    expect(typeOf(parse("let id = fun x -> x in id true"))).toEqual(tBool());
+  });
+
+  it("let-generalization", () => {
+    const ty = typeOf(parse("let id = fun x -> x in (id 1, id true)"));
+    expect(ty).toEqual({ tag: "TTuple", elts: [tInt(), tBool()] });
+  });
+
+  it("recursion", () => {
+    const ty = typeOf(
+      parse("let rec f n = if n<=1 then n else f (n-1) in f 10")
+    );
+    expect(ty).toEqual(tInt());
+  });
+});

--- a/compiler/tyenv.ts
+++ b/compiler/tyenv.ts
@@ -1,0 +1,29 @@
+import { Scheme, Ty } from "./types";
+import { ftvEnv, ftvTy, applyTy, freshTVar, Subst } from "./subst";
+
+export type TyEnv = Map<string, Scheme>;
+
+export function envEmpty(): TyEnv {
+  return new Map();
+}
+
+export function envExtend(env: TyEnv, x: string, sc: Scheme): TyEnv {
+  const newEnv = new Map(env);
+  newEnv.set(x, sc);
+  return newEnv;
+}
+
+export function generalize(env: TyEnv, ty: Ty): Scheme {
+  const envVars = ftvEnv(env);
+  const tyVars = ftvTy(ty);
+  for (const v of envVars) tyVars.delete(v);
+  return { forAll: Array.from(tyVars), ty };
+}
+
+export function instantiate(sc: Scheme): Ty {
+  const subst: Subst = new Map();
+  for (const id of sc.forAll) {
+    subst.set(id, freshTVar());
+  }
+  return applyTy(subst, sc.ty);
+}

--- a/compiler/types.ts
+++ b/compiler/types.ts
@@ -1,0 +1,37 @@
+export type TVarId = number;
+
+export type Ty =
+  | { tag: "TInt" }
+  | { tag: "TBool" }
+  | { tag: "TUnit" }
+  | { tag: "TFun"; from: Ty; to: Ty }
+  | { tag: "TTuple"; elts: Ty[] }
+  | { tag: "TVar"; id: TVarId };
+
+export type Scheme = { forAll: TVarId[]; ty: Ty };
+
+export function tInt(): Ty {
+  return { tag: "TInt" };
+}
+
+export function tBool(): Ty {
+  return { tag: "TBool" };
+}
+
+export function tUnit(): Ty {
+  return { tag: "TUnit" };
+}
+
+export function tFun(a: Ty, b: Ty): Ty {
+  return { tag: "TFun", from: a, to: b };
+}
+
+let nextTVarId = 0;
+
+export function tVar(id?: TVarId): Ty {
+  return { tag: "TVar", id: id ?? nextTVarId++ };
+}
+
+export function tTuple(elts: Ty[]): Ty {
+  return { tag: "TTuple", elts };
+}


### PR DESCRIPTION
## Summary
- add core type definitions and helpers for type variables
- implement substitutions, type environment, and Algorithm W inference
- test type inference on arithmetic, higher-order, tuples, and recursion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5f90770e8832fa4b435e7879b3c35