### PR TITLE
feat: add naive JS interpreter

### DIFF
--- a/compiler/interpret.ts
+++ b/compiler/interpret.ts
@@ -1,0 +1,167 @@
+import { Expr, BinOp } from "./ast";
+
+export type Val =
+  | { tag: "VInt"; v: number }
+  | { tag: "VBool"; v: boolean }
+  | { tag: "VUnit" }
+  | { tag: "VClosure"; param: string; body: Expr; env: Env }
+  | { tag: "VTuple"; elts: Val[] }
+  | { tag: "VBuiltin"; fn: (arg: Val, host: Host) => Val };
+
+export type Env = Map<string, Val>;
+
+export type Host = {
+  print_int(n: number): void;
+  print_bool(b: boolean): void;
+  print_unit(): void;
+  now_ms(): number;
+};
+
+function initialEnv(host: Host): Env {
+  const env: Env = new Map();
+  env.set("print_int", {
+    tag: "VBuiltin",
+    fn(arg, h) {
+      if (arg.tag !== "VInt") throw new Error("print_int expects int");
+      h.print_int(arg.v);
+      return { tag: "VUnit" };
+    }
+  });
+  env.set("print_bool", {
+    tag: "VBuiltin",
+    fn(arg, h) {
+      if (arg.tag !== "VBool") throw new Error("print_bool expects bool");
+      h.print_bool(arg.v);
+      return { tag: "VUnit" };
+    }
+  });
+  env.set("print_unit", {
+    tag: "VBuiltin",
+    fn(arg, h) {
+      if (arg.tag !== "VUnit") throw new Error("print_unit expects unit");
+      h.print_unit();
+      return { tag: "VUnit" };
+    }
+  });
+  env.set("now_ms", {
+    tag: "VBuiltin",
+    fn(arg, h) {
+      if (arg.tag !== "VUnit") throw new Error("now_ms expects unit");
+      return { tag: "VInt", v: h.now_ms() };
+    }
+  });
+  return env;
+}
+
+export function evalExpr(e: Expr, host: Host): Val {
+  const env = initialEnv(host);
+  return evalExprEnv(e, env, host);
+}
+
+function evalExprEnv(e: Expr, env: Env, host: Host): Val {
+  switch (e.tag) {
+    case "Int":
+      return { tag: "VInt", v: e.value };
+    case "Bool":
+      return { tag: "VBool", v: e.value };
+    case "Unit":
+      return { tag: "VUnit" };
+    case "Var": {
+      const v = env.get(e.name);
+      if (!v) throw new Error(`Unbound variable ${e.name}`);
+      return v;
+    }
+    case "Let": {
+      const val = evalExprEnv(e.value, env, host);
+      const newEnv = new Map(env);
+      newEnv.set(e.name, val);
+      return evalExprEnv(e.body, newEnv, host);
+    }
+    case "LetRec": {
+      const newEnv = new Map(env);
+      const clo: Val = {
+        tag: "VClosure",
+        param: e.param,
+        body: e.body,
+        env: newEnv
+      };
+      newEnv.set(e.name, clo);
+      return evalExprEnv(e.inExpr, newEnv, host);
+    }
+    case "Fun":
+      return { tag: "VClosure", param: e.param, body: e.body, env };
+    case "App": {
+      const fnVal = evalExprEnv(e.callee, env, host);
+      const argVal = evalExprEnv(e.arg, env, host);
+      if (fnVal.tag === "VClosure") {
+        const callEnv = new Map(fnVal.env);
+        callEnv.set(fnVal.param, argVal);
+        return evalExprEnv(fnVal.body, callEnv, host);
+      } else if (fnVal.tag === "VBuiltin") {
+        return fnVal.fn(argVal, host);
+      }
+      throw new Error("Attempt to call non-function");
+    }
+    case "If": {
+      const cond = evalExprEnv(e.cond, env, host);
+      if (cond.tag !== "VBool") throw new Error("if condition not boolean");
+      return cond.v
+        ? evalExprEnv(e.then_, env, host)
+        : evalExprEnv(e.else_, env, host);
+    }
+    case "Prim": {
+      const l = evalExprEnv(e.left, env, host);
+      const r = evalExprEnv(e.right, env, host);
+      return evalPrim(e.op, l, r);
+    }
+    case "Tuple":
+      return { tag: "VTuple", elts: e.elts.map((x) => evalExprEnv(x, env, host)) };
+  }
+}
+
+function evalPrim(op: BinOp, l: Val, r: Val): Val {
+  switch (op) {
+    case "+":
+      if (l.tag === "VInt" && r.tag === "VInt")
+        return { tag: "VInt", v: l.v + r.v };
+      break;
+    case "-":
+      if (l.tag === "VInt" && r.tag === "VInt")
+        return { tag: "VInt", v: l.v - r.v };
+      break;
+    case "*":
+      if (l.tag === "VInt" && r.tag === "VInt")
+        return { tag: "VInt", v: l.v * r.v };
+      break;
+    case "=":
+      if (l.tag === r.tag) {
+        switch (l.tag) {
+          case "VInt":
+            return { tag: "VBool", v: l.v === (r as any).v };
+          case "VBool":
+            return { tag: "VBool", v: l.v === (r as any).v };
+          case "VUnit":
+            return { tag: "VBool", v: true };
+          case "VTuple": {
+            const rT = r as any;
+            if (l.elts.length !== rT.elts.length) throw new Error("tuple arity mismatch");
+            for (let i = 0; i < l.elts.length; i++) {
+              const res = evalPrim("=", l.elts[i], rT.elts[i]);
+              if (res.tag !== "VBool" || !res.v) return { tag: "VBool", v: false };
+            }
+            return { tag: "VBool", v: true };
+          }
+        }
+      }
+      break;
+    case "<":
+      if (l.tag === "VInt" && r.tag === "VInt")
+        return { tag: "VBool", v: l.v < r.v };
+      break;
+    case "<=":
+      if (l.tag === "VInt" && r.tag === "VInt")
+        return { tag: "VBool", v: l.v <= r.v };
+      break;
+  }
+  throw new Error(`invalid operands for ${op}`);
+}

--- a/compiler/tests/interpret.spec.ts
+++ b/compiler/tests/interpret.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "../parser";
+import { evalExpr, Host, Val } from "../interpret";
+
+function makeHost() {
+  const out: any[] = [];
+  const host: Host = {
+    print_int(n: number) {
+      out.push(n);
+    },
+    print_bool(b: boolean) {
+      out.push(b);
+    },
+    print_unit() {
+      out.push("unit");
+    },
+    now_ms() {
+      return 123;
+    }
+  };
+  return { host, out };
+}
+
+describe("interpret", () => {
+  it("fib", () => {
+    const { host } = makeHost();
+    const src = "let rec fib n = if n<=1 then n else (fib (n-1)) + (fib (n-2)) in fib 5";
+    const v = evalExpr(parse(src), host);
+    expect(v).toEqual({ tag: "VInt", v: 5 });
+  });
+
+  it("sum_to", () => {
+    const { host } = makeHost();
+    const src = "let rec sum n = if n<=0 then 0 else n + (sum (n-1)) in sum 5";
+    const v = evalExpr(parse(src), host);
+    expect(v).toEqual({ tag: "VInt", v: 15 });
+  });
+
+  it("higher-order closures", () => {
+    const { host } = makeHost();
+    const src = "let add = fun x -> fun y -> x + y in let add5 = add 5 in add5 3";
+    const v = evalExpr(parse(src), host);
+    expect(v).toEqual({ tag: "VInt", v: 8 });
+  });
+
+  it("builtins", () => {
+    const { host, out } = makeHost();
+    const src =
+      "let _ = print_int 41 in let _ = print_bool false in let _ = print_unit () in now_ms ()";
+    const v = evalExpr(parse(src), host);
+    expect(out).toEqual([41, false, "unit"]);
+    expect(v).toEqual({ tag: "VInt", v: 123 });
+  });
+});


### PR DESCRIPTION
## Summary
- implement runtime value model and evaluator with closures and built-in host functions
- test interpreter on recursion, higher-order functions, and printing built-ins

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b60d92d430832fa2a4548c1e4b3f46