### PR TITLE
Implement IR and closure conversion

### DIFF
--- a/compiler/closure.ts
+++ b/compiler/closure.ts
@@ -1,0 +1,189 @@
+import { Expr } from "./ast";
+import { IR, IRFun, IRModule, Temp } from "./ir";
+
+// Free variable analysis
+function freeVars(e: Expr): Set<string> {
+  switch (e.tag) {
+    case "Int":
+    case "Bool":
+    case "Unit":
+      return new Set();
+    case "Var":
+      return new Set([e.name]);
+    case "Let": {
+      const fv = freeVars(e.value);
+      const bodyFv = freeVars(e.body);
+      bodyFv.delete(e.name);
+      return new Set([...fv, ...bodyFv]);
+    }
+    case "LetRec": {
+      const bodyFv = freeVars(e.body);
+      bodyFv.delete(e.name);
+      const inFv = freeVars(e.inExpr);
+      inFv.delete(e.name);
+      return new Set([...bodyFv, ...inFv]);
+    }
+    case "Fun": {
+      const fv = freeVars(e.body);
+      fv.delete(e.param);
+      return fv;
+    }
+    case "App": {
+      const a = freeVars(e.callee);
+      const b = freeVars(e.arg);
+      return new Set([...a, ...b]);
+    }
+    case "If": {
+      const c = freeVars(e.cond);
+      const t = freeVars(e.then_);
+      const el = freeVars(e.else_);
+      return new Set([...c, ...t, ...el]);
+    }
+    case "Prim": {
+      const l = freeVars(e.left);
+      const r = freeVars(e.right);
+      return new Set([...l, ...r]);
+    }
+    case "Tuple": {
+      const sets = e.elts.map(freeVars);
+      return sets.reduce((acc, s) => {
+        s.forEach((x) => acc.add(x));
+        return acc;
+      }, new Set<string>());
+    }
+  }
+}
+
+let nextTemp = 0;
+let nextFun = 0;
+
+function freshTemp(): Temp {
+  return nextTemp++;
+}
+
+export function toIR(e: Expr): IRModule {
+  nextTemp = 0;
+  nextFun = 0;
+  const funs: IRFun[] = [];
+
+  function lower(expr: Expr, env: Map<string, Temp>): IR {
+    switch (expr.tag) {
+      case "Int":
+        return { tag: "ConstI", n: expr.value };
+      case "Bool":
+        return { tag: "ConstB", b: expr.value };
+      case "Unit":
+        return { tag: "Unit" };
+      case "Var": {
+        const t = env.get(expr.name);
+        if (t === undefined) throw new Error(`Unbound variable ${expr.name}`);
+        return { tag: "Var", id: t };
+      }
+      case "Let": {
+        const id = freshTemp();
+        const env2 = new Map(env);
+        env2.set(expr.name, id);
+        return {
+          tag: "Let",
+          id,
+          value: lower(expr.value, env),
+          body: lower(expr.body, env2)
+        };
+      }
+      case "LetRec": {
+        const id = freshTemp();
+        const env2 = new Map(env);
+        env2.set(expr.name, id);
+        const clo = lowerFun(expr.name, expr.param, expr.body, env2);
+        return {
+          tag: "Let",
+          id,
+          value: clo,
+          body: lower(expr.inExpr, env2)
+        };
+      }
+      case "Fun":
+        return lowerFun(undefined, expr.param, expr.body, env);
+      case "App": {
+        const closId = freshTemp();
+        const argId = freshTemp();
+        return {
+          tag: "Let",
+          id: closId,
+          value: lower(expr.callee, env),
+          body: {
+            tag: "Let",
+            id: argId,
+            value: lower(expr.arg, env),
+            body: { tag: "Call", clos: closId, arg: argId }
+          }
+        };
+      }
+      case "If":
+        return {
+          tag: "If",
+          cond: lower(expr.cond, env),
+          then_: lower(expr.then_, env),
+          else_: lower(expr.else_, env)
+        };
+      case "Prim":
+        return {
+          tag: "Prim",
+          op: expr.op,
+          a: lower(expr.left, env),
+          b: lower(expr.right, env)
+        };
+      case "Tuple": {
+        const temps: Temp[] = new Array(expr.elts.length);
+        let body: IR = { tag: "Tuple", elts: temps };
+        for (let i = expr.elts.length - 1; i >= 0; i--) {
+          const t = freshTemp();
+          temps[i] = t;
+          body = {
+            tag: "Let",
+            id: t,
+            value: lower(expr.elts[i], env),
+            body
+          };
+        }
+        return body;
+      }
+    }
+  }
+
+  function lowerFun(name: string | undefined, param: string, body: Expr, env: Map<string, Temp>): IR {
+    const index = nextFun++;
+    const free = Array.from(freeVars(body));
+    const paramTemp = freshTemp();
+    const envTemp = freshTemp();
+    const envForBody = new Map<string, Temp>();
+    envForBody.set(param, paramTemp);
+    const sortedFree = free.filter((x) => x !== param);
+    sortedFree.sort();
+    sortedFree.forEach((fv) => {
+      const t = freshTemp();
+      envForBody.set(fv, t);
+    });
+    let bodyIR = lower(body, envForBody);
+    for (let i = sortedFree.length - 1; i >= 0; i--) {
+      const fv = sortedFree[i];
+      const t = envForBody.get(fv)!;
+      bodyIR = {
+        tag: "Let",
+        id: t,
+        value: { tag: "Proj", tuple: envTemp, index: i },
+        body: bodyIR
+      };
+    }
+    funs.push({ index, param: paramTemp, env: envTemp, body: bodyIR, freeLayout: sortedFree });
+    const freeTemps = sortedFree.map((fv) => {
+      const t = env.get(fv);
+      if (t === undefined) throw new Error(`Unbound free var ${fv}`);
+      return t;
+    });
+    return { tag: "MakeClosure", funIndex: index, free: freeTemps };
+  }
+
+  const main = lower(e, new Map());
+  return { main, funs, nextTemp };
+}

--- a/compiler/ir.ts
+++ b/compiler/ir.ts
@@ -1,0 +1,26 @@
+import { BinOp } from "./ast";
+
+export type Temp = number;
+
+export type IR =
+  | { tag: "ConstI"; n: number }
+  | { tag: "ConstB"; b: boolean }
+  | { tag: "Unit" }
+  | { tag: "Let"; id: Temp; value: IR; body: IR }
+  | { tag: "Var"; id: Temp }
+  | { tag: "If"; cond: IR; then_: IR; else_: IR }
+  | { tag: "Prim"; op: BinOp; a: IR; b: IR }
+  | { tag: "MakeClosure"; funIndex: number; free: Temp[] }
+  | { tag: "Call"; clos: Temp; arg: Temp }
+  | { tag: "Tuple"; elts: Temp[] }
+  | { tag: "Proj"; tuple: Temp; index: number };
+
+export type IRFun = {
+  index: number;
+  param: Temp;
+  env: Temp;
+  body: IR;
+  freeLayout: string[];
+};
+
+export type IRModule = { main: IR; funs: IRFun[]; nextTemp: number };

--- a/compiler/tests/closure.spec.ts
+++ b/compiler/tests/closure.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "../parser";
+import { toIR } from "../closure";
+
+function getMakeClosure(ir: any): any {
+  if (ir.tag === "MakeClosure") return ir;
+  if (ir.tag === "Let") return getMakeClosure(ir.value);
+  return undefined;
+}
+
+describe("closure conversion", () => {
+  it("captures free vars", () => {
+    const mod = toIR(parse("fun x -> fun y -> x + y"));
+    expect(mod.funs.length).toBe(2);
+    const inner = mod.funs[0];
+    expect(inner.freeLayout).toEqual(["x"]);
+    const outerBody = mod.funs[1].body as any;
+    const mk = getMakeClosure(outerBody)!;
+    expect(mk.funIndex).toBe(inner.index);
+    expect(mk.free.length).toBe(1);
+  });
+
+  it("let rec closure has stable index", () => {
+    const mod = toIR(parse("let rec f x = x in f"));
+    const funIndex = mod.funs[0].index;
+    const mk = getMakeClosure(mod.main)!;
+    expect(mk.funIndex).toBe(funIndex);
+  });
+});


### PR DESCRIPTION
## Summary
- add intermediate representation structures for closures and function table
- implement `toIR` to lower AST into closure-converted IR
- test closure conversion including free-variable capture and recursive function indices

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b612e1dc5c832f8d2d23f413b7762c