### PR TITLE
feat: add wasm codegen backend

### DIFF
--- a/compiler/codegen_wat.ts
+++ b/compiler/codegen_wat.ts
@@ -1,0 +1,288 @@
+import { IR, IRFun, IRModule } from "./ir";
+import { HEAP_BASE, TAG_CLOSURE, TAG_TUPLE } from "./runtime_layout";
+
+export type WasmText = string;
+
+const builtinWrappers = [
+  { name: "print_int", importName: "print_int", kind: "print_int" },
+  { name: "print_bool", importName: "print_bool", kind: "print_bool" },
+  { name: "print_unit", importName: "print_unit", kind: "print_unit" },
+  { name: "now_ms", importName: "now_ms", kind: "now_ms" }
+];
+
+export function emitWAT(m: IRModule): WasmText {
+  const lines: string[] = [];
+  lines.push("(module");
+  lines.push(
+    "  (import \"host\" \"print_int\" (func $print_int (param i32)))"
+  );
+  lines.push(
+    "  (import \"host\" \"print_bool\" (func $print_bool (param i32)))"
+  );
+  lines.push("  (import \"host\" \"print_unit\" (func $print_unit))");
+  lines.push(
+    "  (import \"host\" \"now_ms\" (func $now_ms (result i32)))"
+  );
+  lines.push("  (memory (export \"mem\") 2)");
+  lines.push(
+    `  (global $hp (mut i32) (i32.const ${HEAP_BASE}))`
+  );
+  lines.push("  (type $fn (func (param i32 i32) (result i32)))");
+  const tableElems = [
+    "$wrap_print_int",
+    "$wrap_print_bool",
+    "$wrap_print_unit",
+    "$wrap_now_ms",
+    ...m.funs.map((f) => `$f${f.index}`)
+  ];
+  lines.push(`  (table funcref (elem ${tableElems.join(" ")}))`);
+  emitAlloc(lines);
+  emitBuiltinWrappers(lines);
+  m.funs
+    .sort((a, b) => a.index - b.index)
+    .forEach((f) => emitFun(f, lines, m.nextTemp));
+  emitMain(lines, m.main, m.nextTemp);
+  lines.push(")");
+  return lines.join("\n");
+}
+
+function emitAlloc(lines: string[]) {
+  lines.push(
+    "  (func $alloc (param $n i32) (param $tag i32) (result i32)"
+  );
+  lines.push("    (local $p i32)");
+  lines.push("    global.get $hp");
+  lines.push("    local.tee $p");
+  lines.push("    local.get $n");
+  lines.push("    i32.store");
+  lines.push("    local.get $p");
+  lines.push("    i32.const 4");
+  lines.push("    i32.add");
+  lines.push("    local.get $tag");
+  lines.push("    i32.store");
+  lines.push("    global.get $hp");
+  lines.push("    local.get $n");
+  lines.push("    i32.const 4");
+  lines.push("    i32.mul");
+  lines.push("    i32.add");
+  lines.push("    global.set $hp");
+  lines.push("    local.get $p");
+  lines.push("  )");
+}
+
+function emitBuiltinWrappers(lines: string[]) {
+  for (const w of builtinWrappers) {
+    lines.push(
+      `  (func $wrap_${w.importName} (type $fn) (param i32 i32) (result i32)`
+    );
+    switch (w.importName) {
+      case "print_int":
+      case "print_bool":
+        lines.push("    local.get 0");
+        lines.push(`    call $${w.importName}`);
+        lines.push("    i32.const 0");
+        break;
+      case "print_unit":
+        lines.push(`    call $${w.importName}`);
+        lines.push("    i32.const 0");
+        break;
+      case "now_ms":
+        lines.push(`    call $${w.importName}`);
+        break;
+    }
+    lines.push("  )");
+  }
+}
+
+function emitFun(f: IRFun, lines: string[], nTemps: number) {
+  lines.push(
+    `  (func $f${f.index} (type $fn) (param $arg i32) (param $env i32) (result i32)`
+  );
+  emitLocals(lines, nTemps);
+  lines.push(`    local.get $arg`);
+  lines.push(`    local.set $t${f.param}`);
+  lines.push(`    local.get $env`);
+  lines.push(`    local.set $t${f.env}`);
+  emitIR(f.body, lines, "    ");
+  lines.push("  )");
+}
+
+function emitMain(lines: string[], main: IR, nTemps: number) {
+  lines.push("  (func (export \"main\") (result i32)");
+  emitLocals(lines, nTemps);
+  emitBuiltinInits(lines);
+  emitIR(main, lines, "    ");
+  lines.push("  )");
+}
+
+function emitLocals(lines: string[], n: number) {
+  const parts: string[] = [];
+  for (let i = 0; i < n; i++) parts.push(`(local $t${i} i32)`);
+  parts.push("(local $tmp i32)");
+  lines.push(`    ${parts.join(" ")}`);
+}
+
+function emitBuiltinInits(lines: string[]) {
+  for (let i = 0; i < builtinWrappers.length; i++) {
+    lines.push("    i32.const 4");
+    lines.push(`    i32.const ${TAG_CLOSURE}`);
+    lines.push("    call $alloc");
+    lines.push(`    local.set $t${i}`);
+    lines.push(`    local.get $t${i}`);
+    lines.push("    i32.const 8");
+    lines.push("    i32.add");
+    lines.push(`    i32.const ${i}`);
+    lines.push("    i32.store");
+    lines.push(`    local.get $t${i}`);
+    lines.push("    i32.const 12");
+    lines.push("    i32.add");
+    lines.push("    i32.const 0");
+    lines.push("    i32.store");
+  }
+}
+
+function emitMakeClosure(
+  ir: { funIndex: number; free: number[] },
+  lines: string[],
+  indent: string,
+  self?: number
+) {
+  const nWords = ir.free.length + 4;
+  lines.push(`${indent}i32.const ${nWords}`);
+  lines.push(`${indent}i32.const ${TAG_CLOSURE}`);
+  lines.push(`${indent}call $alloc`);
+  if (self !== undefined) {
+    lines.push(`${indent}local.set $t${self}`);
+    lines.push(`${indent}local.get $t${self}`);
+  } else {
+    lines.push(`${indent}local.tee $tmp`);
+  }
+  lines.push(`${indent}i32.const 8`);
+  lines.push(`${indent}i32.add`);
+  lines.push(`${indent}i32.const ${ir.funIndex}`);
+  lines.push(`${indent}i32.store`);
+  if (self !== undefined) {
+    lines.push(`${indent}local.get $t${self}`);
+  } else {
+    lines.push(`${indent}local.get $tmp`);
+  }
+  lines.push(`${indent}i32.const 12`);
+  lines.push(`${indent}i32.add`);
+  lines.push(`${indent}i32.const ${ir.free.length}`);
+  lines.push(`${indent}i32.store`);
+  for (let i = 0; i < ir.free.length; i++) {
+    if (self !== undefined) {
+      lines.push(`${indent}local.get $t${self}`);
+    } else {
+      lines.push(`${indent}local.get $tmp`);
+    }
+    lines.push(`${indent}i32.const ${16 + i * 4}`);
+    lines.push(`${indent}i32.add`);
+    if (self !== undefined && ir.free[i] === self) {
+      lines.push(`${indent}local.get $t${self}`);
+    } else {
+      lines.push(`${indent}local.get $t${ir.free[i]}`);
+    }
+    lines.push(`${indent}i32.store`);
+  }
+  if (self !== undefined) {
+    lines.push(`${indent}local.get $t${self}`);
+  } else {
+    lines.push(`${indent}local.get $tmp`);
+  }
+}
+
+function emitIR(ir: IR, lines: string[], indent: string) {
+  switch (ir.tag) {
+    case "ConstI":
+      lines.push(`${indent}i32.const ${ir.n}`);
+      break;
+    case "ConstB":
+      lines.push(`${indent}i32.const ${ir.b ? 1 : 0}`);
+      break;
+    case "Unit":
+      lines.push(`${indent}i32.const 0`);
+      break;
+    case "Var":
+      lines.push(`${indent}local.get $t${ir.id}`);
+      break;
+    case "Let":
+      if (ir.value.tag === "MakeClosure") {
+        emitMakeClosure(ir.value, lines, indent, ir.id);
+      } else {
+        emitIR(ir.value, lines, indent);
+      }
+      lines.push(`${indent}local.set $t${ir.id}`);
+      emitIR(ir.body, lines, indent);
+      break;
+    case "If":
+      emitIR(ir.cond, lines, indent);
+      lines.push(`${indent}if (result i32)`);
+      emitIR(ir.then_, lines, indent + "  ");
+      lines.push(`${indent}else`);
+      emitIR(ir.else_, lines, indent + "  ");
+      lines.push(`${indent}end`);
+      break;
+    case "Prim":
+      emitIR(ir.a, lines, indent);
+      emitIR(ir.b, lines, indent);
+      switch (ir.op) {
+        case "+":
+          lines.push(`${indent}i32.add`);
+          break;
+        case "-":
+          lines.push(`${indent}i32.sub`);
+          break;
+        case "*":
+          lines.push(`${indent}i32.mul`);
+          break;
+        case "=":
+          lines.push(`${indent}i32.eq`);
+          break;
+        case "<":
+          lines.push(`${indent}i32.lt_s`);
+          break;
+        case "<=":
+          lines.push(`${indent}i32.le_s`);
+          break;
+      }
+      break;
+    case "MakeClosure":
+      emitMakeClosure(ir, lines, indent);
+      break;
+    case "Call":
+      lines.push(`${indent}local.get $t${ir.arg}`);
+      lines.push(`${indent}local.get $t${ir.clos}`);
+      lines.push(`${indent}local.get $t${ir.clos}`);
+      lines.push(`${indent}i32.load offset=8`);
+      lines.push(`${indent}call_indirect (type $fn)`);
+      break;
+    case "Tuple": {
+      const nWords = ir.elts.length + 2;
+      lines.push(`${indent}i32.const ${nWords}`);
+      lines.push(`${indent}i32.const ${TAG_TUPLE}`);
+      lines.push(`${indent}call $alloc`);
+      lines.push(`${indent}local.tee $tmp`);
+      for (let i = 0; i < ir.elts.length; i++) {
+        lines.push(`${indent}local.get $tmp`);
+        lines.push(`${indent}i32.const ${8 + i * 4}`);
+        lines.push(`${indent}i32.add`);
+        lines.push(`${indent}local.get $t${ir.elts[i]}`);
+        lines.push(`${indent}i32.store`);
+      }
+      lines.push(`${indent}local.get $tmp`);
+      break;
+    }
+    case "Proj":
+      lines.push(`${indent}local.get $t${ir.tuple}`);
+      lines.push(`${indent}local.get $t${ir.tuple}`);
+      lines.push(`${indent}i32.load offset=4`); // tag
+      lines.push(`${indent}i32.const 8`);
+      lines.push(`${indent}i32.mul`);
+      lines.push(`${indent}i32.const ${8 + ir.index * 4}`);
+      lines.push(`${indent}i32.add`);
+      lines.push(`${indent}i32.add`);
+      lines.push(`${indent}i32.load`);
+      break;
+  }
+}

--- a/compiler/runtime_layout.ts
+++ b/compiler/runtime_layout.ts
@@ -1,0 +1,10 @@
+export const TAG_TUPLE = 0;
+export const TAG_CLOSURE = 1;
+
+export const HEAP_BASE = 0x100; // bump pointer starts here
+
+// Closure memory layout (i32 words):
+// [ size | tag=1 | code_index | env_len | env0 | env1 | ... ]
+
+// Tuple memory layout:
+// [ size | tag=0 | f0 | f1 | ... ]

--- a/compiler/tests/codegen.spec.ts
+++ b/compiler/tests/codegen.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "../parser";
+import { toIR } from "../closure";
+import { emitWAT } from "../codegen_wat";
+import wabt from "wabt";
+
+async function runWat(src: string, hostImpl?: any) {
+  const ir = toIR(parse(src));
+  const wat = emitWAT(ir);
+  const wabtMod = await wabt();
+  const mod = wabtMod.parseWat("test.wat", wat);
+  const { buffer } = mod.toBinary({});
+  const host = hostImpl || {};
+  const imports = {
+    host: {
+      print_int(n: number) {
+        host.print_int?.(n);
+      },
+      print_bool(b: number) {
+        host.print_bool?.(!!b);
+      },
+      print_unit() {
+        host.print_unit?.();
+      },
+      now_ms() {
+        return host.now_ms ? host.now_ms() : 0;
+      }
+    }
+  };
+  const { instance } = await WebAssembly.instantiate(buffer, imports);
+  const res = (instance.exports.main as Function)();
+  return { res, host };
+}
+
+describe("codegen_wat", () => {
+  it("sum_to", async () => {
+    const src = "let rec sum n = if n<=0 then 0 else n + (sum (n-1)) in sum 5";
+    const { res } = await runWat(src);
+    expect(res).toBe(15);
+  });
+
+  it("builtins", async () => {
+    const logs: any[] = [];
+    const host = {
+      print_int: (n: number) => logs.push(n),
+      print_bool: (b: boolean) => logs.push(b),
+      print_unit: () => logs.push("unit"),
+      now_ms: () => 123
+    };
+    const src =
+      "let _ = print_int 41 in let _ = print_bool false in let _ = print_unit () in now_ms ()";
+    const { res } = await runWat(src, host);
+    expect(logs).toEqual([41, false, "unit"]);
+    expect(res).toBe(123);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "typescript": "^5.4.0",
-    "vitest": "^1.0.0"
+    "vitest": "^1.0.0",
+    "wabt": "^1.0.34"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       vitest:
         specifier: ^1.0.0
         version: 1.6.1
+      wabt:
+        specifier: ^1.0.34
+        version: 1.0.37
 
 packages:
 
@@ -572,6 +575,10 @@ packages:
       jsdom:
         optional: true
 
+  wabt@1.0.37:
+    resolution: {integrity: sha512-2B/TH4ppwtlkUosLtuIimKsTVnqM8aoXxYHnu/WOxiSqa+CGoZXmG+pQyfDQjEKIAc7GqFlJsuCKuK8rIPL1sg==}
+    hasBin: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1050,6 +1057,8 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  wabt@1.0.37: {}
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
- define linear memory layout constants for tuples and closures
- generate WebAssembly text with function table, builtins, and runtime allocator
- compile Tiny OCaml to WAT and run via wabt in tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6152af934832f8d1b24f3dafe0b59