### PR TITLE
Add web app skeleton with wasm runner

### DIFF
--- a/web/App.tsx
+++ b/web/App.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from "react";
+import { parse } from "../compiler/parser";
+import { showAST } from "../compiler/ast_printer";
+import { toIR } from "../compiler/closure";
+import { emitWAT } from "../compiler/codegen_wat";
+import { evalExpr, Val } from "../compiler/interpret";
+import { assembleWAT, runWasm } from "./lib/wasmHost";
+import EditorPane from "./components/EditorPane";
+import OutputTabs from "./components/OutputTabs";
+import Toolbar from "./components/Toolbar";
+import BenchView from "./components/BenchView";
+
+function showVal(v: Val): string {
+  switch (v.tag) {
+    case "VInt":
+      return v.v.toString();
+    case "VBool":
+      return v.v.toString();
+    case "VUnit":
+      return "()";
+    case "VTuple":
+      return "(" + v.elts.map(showVal).join(", ") + ")";
+    case "VClosure":
+      return "<fun>";
+    case "VBuiltin":
+      return "<builtin>";
+  }
+}
+
+export default function App() {
+  const [source, setSource] = useState<string>("let x = 1 in x + 2");
+  const [ast, setAst] = useState<string>("");
+  const [ir, setIr] = useState<string>("");
+  const [wat, setWat] = useState<string>("");
+  const [consoleOut, setConsoleOut] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleParse() {
+    try {
+      const e = parse(source);
+      setAst(showAST(e));
+      const irm = toIR(e);
+      setIr(JSON.stringify(irm, null, 2));
+      const watText = emitWAT(irm);
+      setWat(watText);
+      setError(null);
+    } catch (err: any) {
+      setError(String(err));
+    }
+  }
+
+  function handleRunJS() {
+    try {
+      const e = parse(source);
+      const logs: string[] = [];
+      const host = {
+        print_int(n: number) {
+          logs.push(String(n));
+        },
+        print_bool(b: boolean) {
+          logs.push(String(b));
+        },
+        print_unit() {
+          logs.push("()");
+        },
+        now_ms() {
+          return Date.now();
+        }
+      };
+      const res = evalExpr(e, host);
+      logs.push("=> " + showVal(res));
+      setConsoleOut(logs);
+      setError(null);
+    } catch (err: any) {
+      setError(String(err));
+    }
+  }
+
+  async function handleCompileWAT() {
+    await handleParse();
+  }
+
+  async function handleRunWasm() {
+    try {
+      const e = parse(source);
+      const irm = toIR(e);
+      const watText = emitWAT(irm);
+      setWat(watText);
+      const mod = await assembleWAT(watText);
+      const logs: string[] = [];
+      const imports = {
+        host: {
+          print_int(n: number) {
+            logs.push(String(n));
+          },
+          print_bool(b: number) {
+            logs.push(String(!!b));
+          },
+          print_unit() {
+            logs.push("()");
+          },
+          now_ms() {
+            return Date.now();
+          }
+        }
+      };
+      const res = await runWasm(mod, imports);
+      logs.push("=> " + String(res));
+      setConsoleOut(logs);
+      setError(null);
+    } catch (err: any) {
+      setError(String(err));
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", flex: 1 }}>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        <Toolbar
+          onParse={handleParse}
+          onRunJS={handleRunJS}
+          onCompileWAT={handleCompileWAT}
+          onRunWasm={handleRunWasm}
+        />
+        <div style={{ flex: 1, display: "flex" }}>
+          <EditorPane source={source} onChange={setSource} />
+          <OutputTabs ast={ast} ir={ir} wat={wat} console={consoleOut} />
+        </div>
+        {error && (
+          <div style={{ color: "red", padding: "4px" }}>{error}</div>
+        )}
+      </div>
+      <BenchView />
+    </div>
+  );
+}

--- a/web/components/BenchView.tsx
+++ b/web/components/BenchView.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function BenchView() {
+  return (
+    <div style={{ width: "300px", borderLeft: "1px solid #ccc", padding: "4px" }}>
+      <h3>Benchmarks</h3>
+      <div>Not implemented</div>
+    </div>
+  );
+}

--- a/web/components/EditorPane.tsx
+++ b/web/components/EditorPane.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+type Props = {
+  source: string;
+  onChange(src: string): void;
+};
+
+export default function EditorPane({ source, onChange }: Props) {
+  return (
+    <textarea
+      value={source}
+      onChange={(e) => onChange(e.target.value)}
+      style={{ flex: 1, fontFamily: "monospace" }}
+    />
+  );
+}

--- a/web/components/OutputTabs.tsx
+++ b/web/components/OutputTabs.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from "react";
+
+type Props = {
+  ast: string;
+  ir: string;
+  wat: string;
+  console: string[];
+};
+
+const tabs = ["AST", "IR", "WAT", "Console"] as const;
+
+export default function OutputTabs({ ast, ir, wat, console }: Props) {
+  const [active, setActive] = useState<(typeof tabs)[number]>("AST");
+
+  let content = "";
+  switch (active) {
+    case "AST":
+      content = ast;
+      break;
+    case "IR":
+      content = ir;
+      break;
+    case "WAT":
+      content = wat;
+      break;
+    case "Console":
+      content = console.join("\n");
+      break;
+  }
+
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+      <div style={{ display: "flex", borderBottom: "1px solid #ccc" }}>
+        {tabs.map((t) => (
+          <button
+            key={t}
+            onClick={() => setActive(t)}
+            style={{
+              padding: "4px 8px",
+              background: active === t ? "#ddd" : "#f0f0f0",
+              border: "none",
+              cursor: "pointer"
+            }}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <pre style={{ flex: 1, margin: 0, overflow: "auto" }}>{content}</pre>
+    </div>
+  );
+}

--- a/web/components/Toolbar.tsx
+++ b/web/components/Toolbar.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+type Props = {
+  onParse(): void;
+  onRunJS(): void;
+  onCompileWAT(): void;
+  onRunWasm(): void;
+};
+
+export default function Toolbar({ onParse, onRunJS, onCompileWAT, onRunWasm }: Props) {
+  const btn = {
+    marginRight: "4px",
+  } as React.CSSProperties;
+  return (
+    <div style={{ padding: "4px", borderBottom: "1px solid #ccc" }}>
+      <button style={btn} onClick={onParse}>
+        Parse/Typecheck
+      </button>
+      <button style={btn} onClick={onRunJS}>
+        Run (JS)
+      </button>
+      <button style={btn} onClick={onCompileWAT}>
+        Compile (WAT)
+      </button>
+      <button style={btn} onClick={onRunWasm}>
+        Run (Wasm)
+      </button>
+    </div>
+  );
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Tiny OCaml → Wasm</title>
+    <style>
+      body { font-family: sans-serif; margin: 0; padding: 0; display: flex; flex-direction: column; height: 100vh; }
+      #root { flex: 1; display: flex; flex-direction: column; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="main.tsx"></script>
+  </body>
+</html>

--- a/web/lib/timing.ts
+++ b/web/lib/timing.ts
@@ -1,0 +1,61 @@
+import { parse } from "../../compiler/parser";
+import { evalExpr } from "../../compiler/interpret";
+import { toIR } from "../../compiler/closure";
+import { emitWAT } from "../../compiler/codegen_wat";
+import { assembleWAT, runWasm } from "./wasmHost";
+
+export async function runBench(
+  source: string,
+  opts: { engine: "js" | "wasm"; iterations: number; warmup: number }
+): Promise<{ min: number; median: number; mean: number; stdev: number }> {
+  const times: number[] = [];
+  const total = opts.warmup + opts.iterations;
+
+  if (opts.engine === "js") {
+    const ast = parse(source);
+    const host = {
+      print_int(_n: number) {},
+      print_bool(_b: boolean) {},
+      print_unit() {},
+      now_ms() {
+        return Date.now();
+      }
+    };
+    for (let i = 0; i < total; i++) {
+      const t0 = performance.now();
+      evalExpr(ast, host);
+      const t1 = performance.now();
+      if (i >= opts.warmup) times.push(t1 - t0);
+    }
+  } else {
+    const ast = parse(source);
+    const ir = toIR(ast);
+    const wat = emitWAT(ir);
+    const mod = await assembleWAT(wat);
+    const imports = {
+      host: {
+        print_int(_n: number) {},
+        print_bool(_b: number) {},
+        print_unit() {},
+        now_ms() {
+          return Date.now();
+        }
+      }
+    };
+    for (let i = 0; i < total; i++) {
+      const t0 = performance.now();
+      await runWasm(mod, imports);
+      const t1 = performance.now();
+      if (i >= opts.warmup) times.push(t1 - t0);
+    }
+  }
+
+  times.sort((a, b) => a - b);
+  const min = times[0];
+  const median = times[Math.floor(times.length / 2)];
+  const mean = times.reduce((a, b) => a + b, 0) / times.length;
+  const stdev = Math.sqrt(
+    times.reduce((a, b) => a + (b - mean) * (b - mean), 0) / times.length
+  );
+  return { min, median, mean, stdev };
+}

--- a/web/lib/wabt.js
+++ b/web/lib/wabt.js
@@ -1,0 +1,3 @@
+// Wrapper re-exporting wabt module for browsers/Node
+import wabt from "wabt";
+export default wabt;

--- a/web/lib/wasmHost.ts
+++ b/web/lib/wasmHost.ts
@@ -1,0 +1,29 @@
+import wabt from "wabt";
+
+export async function assembleWAT(wat: string): Promise<WebAssembly.Module> {
+  const wabtMod = await wabt();
+  const parsed = wabtMod.parseWat("module.wat", wat);
+  const { buffer } = parsed.toBinary({});
+  return await WebAssembly.compile(buffer);
+}
+
+export async function runWasm(mod: WebAssembly.Module, imports: any = {}): Promise<number> {
+  const inst = await WebAssembly.instantiate(mod, imports);
+  const res = (inst.exports.main as Function)();
+  return res as number;
+}
+
+export const defaultHost = {
+  print_int(n: number) {
+    console.log(n);
+  },
+  print_bool(b: boolean) {
+    console.log(b);
+  },
+  print_unit() {
+    console.log("()");
+  },
+  now_ms() {
+    return Date.now();
+  }
+};

--- a/web/main.tsx
+++ b/web/main.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+const container = document.getElementById("root");
+if (container) {
+  const root = createRoot(container);
+  root.render(<App />);
+}


### PR DESCRIPTION
## Summary
- Add minimal React-based UI with editor, toolbar, and output tabs
- Provide wasm host utilities for assembling and running WAT
- Include basic benchmarking harness for JS vs Wasm execution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b62db9cab8832f9730d4ad8275bd59