### PR TITLE
feat: add benchmark suite

### DIFF
--- a/bench/programs/fib_rec.tiny
+++ b/bench/programs/fib_rec.tiny
@@ -1,0 +1,5 @@
+let rec fib n =
+  if n <= 1 then n
+  else (fib (n - 1)) + (fib (n - 2))
+in
+fib 20

--- a/bench/programs/hof_map_fold.tiny
+++ b/bench/programs/hof_map_fold.tiny
@@ -1,0 +1,12 @@
+let rec map f n =
+  if n <= 0 then 0
+  else (f n) + map f (n - 1)
+in
+let rec fold f n acc =
+  if n <= 0 then acc
+  else fold f (n - 1) (f acc n)
+in
+let inc x = x + 1 in
+let add a b = a + b in
+let mapped = map inc 100 in
+fold add 100 mapped

--- a/bench/programs/sum_tail.tiny
+++ b/bench/programs/sum_tail.tiny
@@ -1,0 +1,5 @@
+let rec sum n acc =
+  if n <= 0 then acc
+  else sum (n - 1) (acc + n)
+in
+sum 1000 0

--- a/bench/programs/tuple_proj.tiny
+++ b/bench/programs/tuple_proj.tiny
@@ -1,0 +1,6 @@
+let t = (1, 2, 3, 4, 5) in
+let rec loop n =
+  if n <= 0 then 0
+  else if t = t then loop (n - 1) else 0
+in
+loop 10000

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,21 @@
+# Benchmarks
+
+The project includes a tiny harness to compare performance of the JavaScript
+interpreter against the generated WebAssembly. Benchmark programs live under
+`bench/programs` and can be executed from the **Benchmarks** panel in the web
+UI.
+
+## Programs
+
+- `fib_rec.tiny` – naive recursive Fibonacci.
+- `sum_tail.tiny` – tail recursive summation.
+- `hof_map_fold.tiny` – exercises higher‑order functions and closures.
+- `tuple_proj.tiny` – creates a tuple and repeatedly compares it to itself,
+  stressing tuple loads.
+
+## Running
+
+Open the web app and click **Run all benchmarks**. Each program is run in both
+engines with a warm‑up phase. The median execution time for the JS interpreter
+and the compiled Wasm module are shown along with min/mean/stdev statistics.
+Speedup is reported as `JS_time / Wasm_time`.


### PR DESCRIPTION
## Summary
- add sample benchmark programs and docs
- implement BenchView with speedup chart/table comparing JS vs Wasm
- expose benchmarking harness

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b64d74e7f8832f9e22b707ed6a2002