### PR TITLE
chore: run web server in dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,14 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "dev": "vite web",
+    "build": "tsc"
   },
   "devDependencies": {
     "typescript": "^5.4.0",
+    "vite": "^5.4.0",
     "vitest": "^1.0.0",
     "wabt": "^1.0.34"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
+      vite:
+        specifier: ^5.4.0
+        version: 5.4.19
       vitest:
         specifier: ^1.0.0
         version: 1.6.1


### PR DESCRIPTION
## Summary
- run Vite dev server from the `dev` script
- add a `test:watch` script and include Vite as a dev dependency

## Testing
- `npm run dev -- --help`
- `npm test`
- `npm run build -- --noEmit` *(fails: Property 'instance' does not exist on type 'Instance')*

------
https://chatgpt.com/codex/tasks/task_e_68b6646199a4832fa85c902565a4dfb1