### PR TITLE
Avoid stack overflow in tuple projection benchmark

### DIFF
--- a/bench/programs/tuple_proj.tiny
+++ b/bench/programs/tuple_proj.tiny
@@ -3,4 +3,5 @@ let rec loop n =
   if n <= 0 then 0
   else if t = t then loop (n - 1) else 0
 in
-loop 10000
+(* Reduce iteration count to avoid exceeding the WebAssembly stack depth during recursion. *)
+loop 1000


### PR DESCRIPTION
## Summary
- Reduce recursive iteration count in tuple projection benchmark to prevent WebAssembly stack overflow when running all benchmarks

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b66eb48f08832fb61396582c03941a