### PR TITLE
Fix function application precedence

### DIFF
--- a/compiler/parser.ts
+++ b/compiler/parser.ts
@@ -191,16 +191,7 @@ class Parser {
       const body = this.parseExpr();
       return { tag: "Fun", param, body };
     }
-    return this.parseApp();
-  }
-
-  private parseApp(): Expr {
-    let expr = this.parseCmp();
-    while (isAtomStart(this.peek())) {
-      const arg = this.parseAtom();
-      expr = { tag: "App", callee: expr, arg };
-    }
-    return expr;
+    return this.parseCmp();
   }
 
   private parseCmp(): Expr {
@@ -236,10 +227,19 @@ class Parser {
   }
 
   private parseMul(): Expr {
-    let expr = this.parseAtom();
+    let expr = this.parseApp();
     while (this.matchSymbol("*")) {
-      const right = this.parseAtom();
+      const right = this.parseApp();
       expr = { tag: "Prim", op: "*", left: expr, right };
+    }
+    return expr;
+  }
+
+  private parseApp(): Expr {
+    let expr = this.parseAtom();
+    while (isAtomStart(this.peek())) {
+      const arg = this.parseAtom();
+      expr = { tag: "App", callee: expr, arg };
     }
     return expr;
   }

--- a/compiler/tests/parser.spec.ts
+++ b/compiler/tests/parser.spec.ts
@@ -202,4 +202,23 @@ describe("parser", () => {
     };
     expect(showAST(ast)).toEqual(showAST(expected));
   });
+
+  it("f x + g y parses as (f x) + (g y)", () => {
+    const ast = parse("f x + g y");
+    const expected: Expr = {
+      tag: "Prim",
+      op: "+",
+      left: {
+        tag: "App",
+        callee: { tag: "Var", name: "f" },
+        arg: { tag: "Var", name: "x" }
+      },
+      right: {
+        tag: "App",
+        callee: { tag: "Var", name: "g" },
+        arg: { tag: "Var", name: "y" }
+      }
+    };
+    expect(showAST(ast)).toEqual(showAST(expected));
+  });
 });


### PR DESCRIPTION
## Summary
- ensure function application binds tighter than arithmetic by restructuring parser
- add test covering application vs addition precedence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b67387722c832f9881d081983c4f7b