### PR TITLE
fix: cast instantiate result

### DIFF
--- a/compiler/tests/codegen.spec.ts
+++ b/compiler/tests/codegen.spec.ts
@@ -9,7 +9,7 @@ async function runWat(src: string, hostImpl?: any) {
   const wat = emitWAT(ir);
   const wabtMod = await wabt();
   const mod = wabtMod.parseWat("test.wat", wat);
-  const { buffer } = mod.toBinary({});
+  const { buffer } = mod.toBinary({}) as { buffer: Uint8Array };
   const host = hostImpl || {};
   const imports = {
     host: {
@@ -27,7 +27,10 @@ async function runWat(src: string, hostImpl?: any) {
       }
     }
   };
-  const { instance } = await WebAssembly.instantiate(buffer, imports);
+  const { instance } = (await WebAssembly.instantiate(
+    buffer,
+    imports
+  )) as unknown as WebAssembly.WebAssemblyInstantiatedSource;
   const res = (instance.exports.main as Function)();
   return { res, host };
 }


### PR DESCRIPTION
## Summary
- fix failing build by casting WebAssembly.instantiate result to include instance field

## Testing
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b687d19b74832fbcc493eb16cc4a03