### PR TITLE
Fix function table order for closures

### DIFF
--- a/compiler/codegen_wat.ts
+++ b/compiler/codegen_wat.ts
@@ -28,19 +28,18 @@ export function emitWAT(m: IRModule): WasmText {
     `  (global $hp (mut i32) (i32.const ${HEAP_BASE}))`
   );
   lines.push("  (type $fn (func (param i32 i32) (result i32)))");
+  const sortedFuns = m.funs.slice().sort((a, b) => a.index - b.index);
   const tableElems = [
     "$wrap_print_int",
     "$wrap_print_bool",
     "$wrap_print_unit",
     "$wrap_now_ms",
-    ...m.funs.map((f) => `$f${f.index}`)
+    ...sortedFuns.map((f) => `$f${f.index}`)
   ];
   lines.push(`  (table funcref (elem ${tableElems.join(" ")}))`);
   emitAlloc(lines);
   emitBuiltinWrappers(lines);
-  m.funs
-    .sort((a, b) => a.index - b.index)
-    .forEach((f) => emitFun(f, lines, m.nextTemp));
+  sortedFuns.forEach((f) => emitFun(f, lines, m.nextTemp));
   emitMain(lines, m.main, m.nextTemp);
   lines.push(")");
   return lines.join("\n");

--- a/compiler/tests/codegen.spec.ts
+++ b/compiler/tests/codegen.spec.ts
@@ -53,4 +53,23 @@ describe("codegen_wat", () => {
     expect(logs).toEqual([41, false, "unit"]);
     expect(res).toBe(123);
   });
+
+  it("hof_map_fold", async () => {
+    const src = `
+let rec map f n =
+  if n <= 0 then 0
+  else (f n) + map f (n - 1)
+in
+let rec fold f n acc =
+  if n <= 0 then acc
+  else fold f (n - 1) (f acc n)
+in
+let inc x = x + 1 in
+let add a b = a + b in
+let mapped = map inc 100 in
+fold add 100 mapped
+`;
+    const { res } = await runWat(src);
+    expect(res).toBe(10200);
+  });
 });


### PR DESCRIPTION
## Summary
- Sort generated functions before building the WebAssembly table
- Add regression test covering higher-order map/fold benchmark

## Testing
- `pnpm test`
- `pnpm dlx tsx - <<'TSX'
import { parse } from './compiler/parser'
import { toIR } from './compiler/closure'
import { emitWAT } from './compiler/codegen_wat'
import wabt from 'wabt'
import fs from 'fs/promises'

const src = await fs.readFile('bench/programs/hof_map_fold.tiny','utf8');
const ir = toIR(parse(src));
const wat = emitWAT(ir);
const wabtMod = await wabt();
const mod = wabtMod.parseWat('tmp.wat', wat);
const { buffer } = mod.toBinary({});
const imports = { host: { print_int(){}, print_bool(){}, print_unit(){}, now_ms(){ return 0; } } };
const { instance } = await WebAssembly.instantiate(buffer, imports);
console.log('result', instance.exports.main());
TSX
`

------
https://chatgpt.com/codex/tasks/task_e_68b684ae60e0832faf4b1526f30c2863