### PR TITLE
Restore higher-order benchmark

### DIFF
--- a/bench/programs/hof_map_fold.tiny
+++ b/bench/programs/hof_map_fold.tiny
@@ -1,10 +1,18 @@
-let rec map f n =
-  if n <= 0 then 0
-  else (f n) + map f (n - 1)
+let map f n =
+  let rec loop n =
+    fun acc ->
+      if n <= 0 then acc
+      else (loop (n - 1)) (acc + f n)
+  in
+  (loop n) 0
 in
-let rec fold f n acc =
-  if n <= 0 then acc
-  else fold f (n - 1) (f acc n)
+let fold f n init =
+  let rec loop n =
+    fun acc ->
+      if n <= 0 then acc
+      else (loop (n - 1)) (f acc n)
+  in
+  (loop n) init
 in
 let inc x = x + 1 in
 let add a b = a + b in

--- a/bench/programs/tuple_proj.tiny
+++ b/bench/programs/tuple_proj.tiny
@@ -3,5 +3,4 @@ let rec loop n =
   if n <= 0 then 0
   else if t = t then loop (n - 1) else 0
 in
-(* Reduce iteration count to avoid exceeding the WebAssembly stack depth during recursion. *)
 loop 1000


### PR DESCRIPTION
## Summary
- add back `hof_map_fold` using a curried accumulator to avoid stack overflow
- restore benchmark list in docs and UI
- reset other benchmarks to their original iteration counts

## Testing
- `pnpm test` *(fails: No test files found)*
- `pnpm dlx tsx run_all_bench.ts` *(tuple_proj fails: WebAssembly.compile expected stack mismatch; other benchmarks including `hof_map_fold` run)*

------
https://chatgpt.com/codex/tasks/task_e_68b68eb972fc832fa69e68ca23e0368a