### PR TITLE
Fix tuple codegen stack imbalance

### DIFF
--- a/compiler/codegen_wat.ts
+++ b/compiler/codegen_wat.ts
@@ -262,7 +262,7 @@ function emitIR(ir: IR, lines: string[], indent: string) {
       lines.push(`${indent}i32.const ${nWords}`);
       lines.push(`${indent}i32.const ${TAG_TUPLE}`);
       lines.push(`${indent}call $alloc`);
-      lines.push(`${indent}local.tee $tmp`);
+      lines.push(`${indent}local.set $tmp`);
       for (let i = 0; i < ir.elts.length; i++) {
         lines.push(`${indent}local.get $tmp`);
         lines.push(`${indent}i32.const ${8 + i * 4}`);


### PR DESCRIPTION
## Summary
- use `local.set` instead of `local.tee` when emitting tuple allocations to avoid leaving an extra value on the stack

## Testing
- `npx vitest run --root .`
- `npx tsx /tmp/runBench.ts ./bench/programs/tuple_proj.tiny`


------
https://chatgpt.com/codex/tasks/task_e_68b6fb1193a4832f8c7901aaaa3419c0