### PR TITLE
Handle missing wasm benchmark speedup

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -18,4 +18,6 @@ UI.
 Open the web app and click **Run all benchmarks**. Each program is run in both
 engines with a warm‑up phase. The median execution time for the JS interpreter
 and the compiled Wasm module are shown along with min/mean/stdev statistics.
-Speedup is reported as `JS_time / Wasm_time`.
+Speedup is reported as `JS_time / Wasm_time`, falling back to the Wasm mean if
+the median is zero. Results are shown with additional decimal precision so that
+even extremely fast Wasm runs contribute a finite speedup value.

--- a/web/components/BenchView.tsx
+++ b/web/components/BenchView.tsx
@@ -43,7 +43,10 @@ export default function BenchView() {
           warmup: 1
         });
       }
-      const speedup = stats.js.median / stats.wasm.median;
+      const wasmTime =
+        stats.wasm.median > 0 ? stats.wasm.median : stats.wasm.mean;
+      const speedup =
+        wasmTime > 0 ? stats.js.median / wasmTime : NaN;
       out[p.name] = { js: stats.js, wasm: stats.wasm, speedup };
     }
     setResults(out);
@@ -86,7 +89,8 @@ export default function BenchView() {
               />
             </div>
             <div style={{ fontSize: "12px" }}>
-              Speedup: {r.speedup.toFixed(2)}x
+              Speedup:{" "}
+              {Number.isFinite(r.speedup) ? `${r.speedup.toFixed(2)}x` : "N/A"}
             </div>
             <table
               style={{
@@ -109,10 +113,10 @@ export default function BenchView() {
                 {engines.map((e) => (
                   <tr key={e}>
                     <td>{e}</td>
-                    <td>{r[e].min.toFixed(2)}</td>
-                    <td>{r[e].median.toFixed(2)}</td>
-                    <td>{r[e].mean.toFixed(2)}</td>
-                    <td>{r[e].stdev.toFixed(2)}</td>
+                    <td>{r[e].min.toFixed(4)}</td>
+                    <td>{r[e].median.toFixed(4)}</td>
+                    <td>{r[e].mean.toFixed(4)}</td>
+                    <td>{r[e].stdev.toFixed(4)}</td>
                   </tr>
                 ))}
               </tbody>


### PR DESCRIPTION
## Summary
- compute speedup using Wasm mean when median is zero
- display benchmark timings with four decimal places for very fast runs
- document speedup calculation and additional timing precision

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ffdc2014832f90471e0b303463e9