### PR TITLE
Expand benchmark loops for measurable Wasm time

### DIFF
--- a/bench/programs/sum_tail.tiny
+++ b/bench/programs/sum_tail.tiny
@@ -2,4 +2,4 @@ let rec sum n acc =
   if n <= 0 then acc
   else sum (n - 1) (acc + n)
 in
-sum 1000 0
+sum 1000000 0

--- a/bench/programs/tuple_proj.tiny
+++ b/bench/programs/tuple_proj.tiny
@@ -3,4 +3,4 @@ let rec loop n =
   if n <= 0 then 0
   else if t = t then loop (n - 1) else 0
 in
-loop 1000
+loop 1000000

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -8,9 +8,9 @@ UI.
 ## Programs
 
 - `fib_rec.tiny` – naive recursive Fibonacci.
-- `sum_tail.tiny` – tail recursive summation.
+- `sum_tail.tiny` – tail recursive summation over one million numbers.
 - `hof_map_fold.tiny` – exercises higher‑order functions and closures.
-- `tuple_proj.tiny` – creates a tuple and repeatedly compares it to itself,
+- `tuple_proj.tiny` – creates a tuple and compares it to itself one million times,
   stressing tuple loads.
 
 ## Running


### PR DESCRIPTION
## Summary
- Increase iteration counts in `sum_tail.tiny` and `tuple_proj.tiny` so Wasm runs take measurable time
- Document heavier benchmark workloads

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68b702fcef90832f93d20b27f9b49c36