### PR TITLE
Avoid stack overflow in heavy benchmarks

### DIFF
--- a/bench/programs/sum_tail.tiny
+++ b/bench/programs/sum_tail.tiny
@@ -1,5 +1,17 @@
-let rec sum n acc =
+let rec outer n acc =
   if n <= 0 then acc
-  else sum (n - 1) (acc + n)
+  else
+    let rec middle m acc2 =
+      if m <= 0 then acc2
+      else
+        let rec inner k acc3 =
+          if k <= 0 then acc3
+          else inner (k - 1) (acc3 + k)
+        in
+        let acc2' = inner 1000 acc2 in
+        middle (m - 1) acc2'
+    in
+    let acc' = middle 100 acc in
+    outer (n - 1) acc'
 in
-sum 1000 0
+outer 100 0

--- a/bench/programs/tuple_proj.tiny
+++ b/bench/programs/tuple_proj.tiny
@@ -1,6 +1,20 @@
 let t = (1, 2, 3, 4, 5) in
-let rec loop n =
-  if n <= 0 then 0
-  else if t = t then loop (n - 1) else 0
+let rec outer n acc =
+  if n <= 0 then acc
+  else
+    let rec middle m acc2 =
+      if m <= 0 then acc2
+      else
+        let rec inner k acc3 =
+          if k <= 0 then acc3
+          else
+            let acc3' = if t = t then acc3 + 1 else acc3 in
+            inner (k - 1) acc3'
+        in
+        let acc2' = inner 1000 acc2 in
+        middle (m - 1) acc2'
+    in
+    let acc' = middle 100 acc in
+    outer (n - 1) acc'
 in
-loop 1000
+outer 100 0

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -8,10 +8,11 @@ UI.
 ## Programs
 
 - `fib_rec.tiny` – naive recursive Fibonacci.
-- `sum_tail.tiny` – tail recursive summation.
+- `sum_tail.tiny` – three nested loops sum ten million numbers while keeping
+  recursion depth manageable.
 - `hof_map_fold.tiny` – exercises higher‑order functions and closures.
-- `tuple_proj.tiny` – creates a tuple and repeatedly compares it to itself,
-  stressing tuple loads.
+- `tuple_proj.tiny` – compares a tuple to itself ten million times using
+  nested loops to avoid deep recursion.
 
 ## Running
 


### PR DESCRIPTION
## Summary
- Remove top-level comments that broke TinyOCaml parsing and scale inner loops to 1000 iterations for heavier workloads
- Run ten million tuple comparisons and additions while keeping recursion depth manageable
- Document the expanded benchmark workloads and their stack-safe loop structure

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68b702fcef90832f93d20b27f9b49c36