### PR TITLE
Fix free var analysis for let rec parameters

### DIFF
--- a/compiler/closure.ts
+++ b/compiler/closure.ts
@@ -19,6 +19,7 @@ function freeVars(e: Expr): Set<string> {
     case "LetRec": {
       const bodyFv = freeVars(e.body);
       bodyFv.delete(e.name);
+      bodyFv.delete(e.param);
       const inFv = freeVars(e.inExpr);
       inFv.delete(e.name);
       return new Set([...bodyFv, ...inFv]);

--- a/compiler/tests/closure.spec.ts
+++ b/compiler/tests/closure.spec.ts
@@ -26,4 +26,17 @@ describe("closure conversion", () => {
     const mk = getMakeClosure(mod.main)!;
     expect(mk.funIndex).toBe(funIndex);
   });
+
+  it("handles nested let rec with multiple params", () => {
+    const src = `
+      let rec outer n acc =
+        let rec inner k acc2 =
+          if k <= 0 then acc2 else inner (k - 1) (acc2 + k)
+        in
+        inner 10 acc
+      in
+      outer 5 0
+    `;
+    expect(() => toIR(parse(src))).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- treat `let rec` parameters as bound variables in free-var analysis
- add regression test for nested recursive functions

## Testing
- `npx vitest run --root .`

------
https://chatgpt.com/codex/tasks/task_e_68b70b77bf8c832f91ac20ed4a6d2aff