### PR TITLE
Avoid recursive self-capture in closure conversion

### DIFF
--- a/compiler/tests/closure.spec.ts
+++ b/compiler/tests/closure.spec.ts
@@ -39,4 +39,17 @@ describe("closure conversion", () => {
     `;
     expect(() => toIR(parse(src))).not.toThrow();
   });
+
+  it("does not capture its own name in recursive helpers", () => {
+    const src = `
+      let rec loop n =
+        fun acc ->
+          if n <= 0 then acc else (loop (n - 1)) (acc + 1)
+      in
+      (loop 3) 0
+    `;
+    const mod = toIR(parse(src));
+    expect(mod.funs[0].freeLayout).toContain("loop");
+    expect(mod.funs[1].freeLayout).not.toContain("loop");
+  });
 });


### PR DESCRIPTION
## Summary
- prevent `lowerFun` from treating a function's own name as a free variable
- materialize a fresh self-closure inside the body for recursive calls
- add regression test ensuring recursive helpers don't capture themselves

## Testing
- `npx vitest run --dir compiler`


------
https://chatgpt.com/codex/tasks/task_e_68b72920ce10832f8a592353b6f7bfe2