### PR TITLE
Fix recursive closure capture and function table ordering

### DIFF
--- a/compiler/closure.ts
+++ b/compiler/closure.ts
@@ -229,6 +229,15 @@ export function toIR(e: Expr): IRModule {
       envForBody.set(fv, t);
     });
     let bodyIR = lower(body, envForBody);
+    if (selfTemp !== undefined) {
+      const freeLocals = sortedFree.map((fv) => envForBody.get(fv)!);
+      bodyIR = {
+        tag: "Let",
+        id: selfTemp,
+        value: { tag: "MakeClosure", funIndex: index, free: freeLocals },
+        body: bodyIR
+      };
+    }
     for (let i = sortedFree.length - 1; i >= 0; i--) {
       const fv = sortedFree[i];
       const t = envForBody.get(fv)!;
@@ -236,15 +245,6 @@ export function toIR(e: Expr): IRModule {
         tag: "Let",
         id: t,
         value: { tag: "Proj", tuple: envTemp, index: i },
-        body: bodyIR
-      };
-    }
-    if (selfTemp !== undefined) {
-      const freeLocals = sortedFree.map((fv) => envForBody.get(fv)!);
-      bodyIR = {
-        tag: "Let",
-        id: selfTemp,
-        value: { tag: "MakeClosure", funIndex: index, free: freeLocals },
         body: bodyIR
       };
     }

--- a/compiler/codegen_wat.ts
+++ b/compiler/codegen_wat.ts
@@ -28,19 +28,18 @@ export function emitWAT(m: IRModule): WasmText {
     `  (global $hp (mut i32) (i32.const ${HEAP_BASE}))`
   );
   lines.push("  (type $fn (func (param i32 i32) (result i32)))");
+  const sortedFuns = [...m.funs].sort((a, b) => a.index - b.index);
   const tableElems = [
     "$wrap_print_int",
     "$wrap_print_bool",
     "$wrap_print_unit",
     "$wrap_now_ms",
-    ...m.funs.map((f) => `$f${f.index}`)
+    ...sortedFuns.map((f) => `$f${f.index}`)
   ];
   lines.push(`  (table funcref (elem ${tableElems.join(" ")}))`);
   emitAlloc(lines);
   emitBuiltinWrappers(lines);
-  m.funs
-    .sort((a, b) => a.index - b.index)
-    .forEach((f) => emitFun(f, lines));
+  sortedFuns.forEach((f) => emitFun(f, lines));
   emitMain(lines, m.main);
   lines.push(")");
   return lines.join("\n");

--- a/compiler/tests/codegen.spec.ts
+++ b/compiler/tests/codegen.spec.ts
@@ -56,4 +56,16 @@ describe("codegen_wat", () => {
     expect(logs).toEqual([41, false, "unit"]);
     expect(res).toBe(123);
   });
+
+  it("fib", async () => {
+    const src = `let fib n =
+  let rec aux a b i =
+    if i = n then a
+    else aux b (a + b) (i + 1)
+  in
+  aux 0 1 0
+in fib 25`;
+    const { res } = await runWat(src);
+    expect(res).toBe(75025);
+  });
 });


### PR DESCRIPTION
## Summary
- sort generated functions before building the WebAssembly function table
- capture free variables before creating recursive closures
- add regression test for `fib` nested recursion

## Testing
- `npx vitest run --root .`

------
https://chatgpt.com/codex/tasks/task_e_68b73687d3c8832fbfbbf919cca73d5b