### PR TITLE
Increase wasm memory for benchmarks

### DIFF
--- a/compiler/codegen_wat.ts
+++ b/compiler/codegen_wat.ts
@@ -23,7 +23,7 @@ export function emitWAT(m: IRModule): WasmText {
   lines.push(
     "  (import \"host\" \"now_ms\" (func $now_ms (result i32)))"
   );
-  lines.push("  (memory (export \"mem\") 2)");
+  lines.push("  (memory (export \"mem\") 10)");
   lines.push(
     `  (global $hp (mut i32) (i32.const ${HEAP_BASE}))`
   );


### PR DESCRIPTION
## Summary
- Expand initial WebAssembly memory from 2 pages to 10 pages to prevent heap exhaustion

## Testing
- `npx tsx -e "import fs from 'fs'; import {runBench} from './web/lib/timing'; const src=fs.readFileSync('bench/programs/tuple_proj.tiny','utf8'); runBench(src,{engine:'wasm',iterations:2,warmup:1}).then(res=>console.log(res)).catch(err=>console.error('err',err));"`
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74183dcb0832fac91a3b4572418ac