### PR TITLE
Increase benchmark sample size to 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ INT   := [0-9]+
 
 ## Benchmarks
 
-Runs benchmark programs in both JS and Wasm engines. Each test warms both engines, randomizes run order, and reports median, min, mean, and stdev. "Run all benchmarks" reproduces results with a JS vs Wasm speedup chart and table.
+Runs benchmark programs in both JS and Wasm engines. Each test warms both engines, uses a sample size of ten iterations, randomizes run order, and reports median, min, mean, and stdev. "Run all benchmarks" reproduces results with a JS vs Wasm speedup chart and table.
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -17,8 +17,9 @@ UI.
 ## Running
 
 Open the web app and click **Run all benchmarks**. Each program is run in both
-engines with a warm‑up phase. The median execution time for the JS interpreter
-and the compiled Wasm module are shown along with min/mean/stdev statistics.
-Speedup is reported as `JS_time / Wasm_time`, falling back to the Wasm mean if
-the median is zero. Results are shown with additional decimal precision so that
-even extremely fast Wasm runs contribute a finite speedup value.
+engines with a warm‑up phase and a sample size of ten iterations. The median
+execution time for the JS interpreter and the compiled Wasm module are shown
+along with min/mean/stdev statistics. Speedup is reported as
+`JS_time / Wasm_time`, falling back to the Wasm mean if the median is zero.
+Results are shown with additional decimal precision so that even extremely fast
+Wasm runs contribute a finite speedup value.

--- a/web/components/BenchView.tsx
+++ b/web/components/BenchView.tsx
@@ -39,7 +39,7 @@ export default function BenchView() {
       for (const eng of order) {
         stats[eng] = await runBench(src, {
           engine: eng,
-          iterations: 2,
+          iterations: 10,
           warmup: 1
         });
       }


### PR DESCRIPTION
## Summary
- expand benchmark runs to use 10 recorded iterations
- document benchmark sample size in README and docs

## Testing
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74c456ab0832f90ae44b6095d8dc2